### PR TITLE
Compilation Fixes for ramulator-pim

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ cd ramulator
 make -j
 ```
 
+Alternatively, to resolve all dependencies on the common libraries, you can use the below commands:
+```
+sh compileramulator.sh
+```
+
+
 ## Generating Traces with ZSim 
 
 There are three steps to generate traces with ZSim:

--- a/common/DRAMPower/Makefile
+++ b/common/DRAMPower/Makefile
@@ -70,9 +70,9 @@ ALLOBJECTS := ${ALLSOURCES:.cc=.o}
 DEPENDENCIES := ${ALLSOURCES:.cc=.d}
 
 # Warning flags for deprecated files
-DEPWARNFLAGS := -W -pedantic-errors -Wextra -Werror \
+DEPWARNFLAGS := -W -pedantic-errors -Wextra \
              -Wformat -Wformat-nonliteral -Wpointer-arith \
-             -Wcast-align -Wall -Werror
+             -Wcast-align -Wall
 
 # Sum up the flags.
 DEPCXXFLAGS := -O ${DEPWARNFLAGS} ${DBGCXXFLAGS} ${OPTCXXFLAGS} -std=c++0x
@@ -93,7 +93,7 @@ XERCES_LDFLAGS := -L$(XERCES_LIB) -lxerces-c
 # Targets
 ##########################################
 
-all: ${BINARY} src/libdrampower.a parserlib traces
+all: ${BINARY} src/libdrampower.a parserlib
 
 $(BINARY): ${XMLPARSEROBJECTS} ${CLIOBJECTS} src/libdrampower.a
 	$(CXX) ${CXXFLAGS} $(LDFLAGS) -o $@ $^ -Lsrc/ $(XERCES_LDFLAGS) -ldrampower

--- a/common/DRAMPower/common.mk
+++ b/common/DRAMPower/common.mk
@@ -40,7 +40,7 @@
 # CXX is a predefined variable of GNU Make. Thus, the conditional assignment
 # here may not take effect. If you want to force another compiler here use
 # ':=' instead of '?='.
-CXX ?= g++
+CXX ?= g++-6
 
 ifeq ($(COVERAGE),1)
 	GCOVFLAGS := -fprofile-arcs -ftest-coverage
@@ -52,9 +52,9 @@ endif
 DBGCXXFLAGS ?= -g ${GCOVFLAGS}
 
 # Warning flags
-WARNFLAGS := -W -pedantic-errors -Wextra -Werror \
+WARNFLAGS := -W -pedantic-errors -Wextra \
              -Wformat -Wformat-nonliteral -Wpointer-arith \
-             -Wcast-align -Wconversion -Wall -Werror
+             -Wcast-align -Wconversion -Wall 
 
 CXXFLAGS := -O ${WARNFLAGS} ${DBGCXXFLAGS} ${OPTCXXFLAGS} -std=c++0x
 

--- a/compileramulator.sh
+++ b/compileramulator.sh
@@ -1,0 +1,4 @@
+cd ./common/DRAMPower
+make -j
+cd ../../ramulator
+make -j

--- a/ramulator/Makefile
+++ b/ramulator/Makefile
@@ -11,7 +11,7 @@ OBJS := $(patsubst $(SRCDIR)/%.cpp, $(OBJDIR)/%.o, $(SRCS))
 CXX := g++-6
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S), Linux)
-  CXXFLAGS := -O3 -std=c++11 -g -w -Wall -I../../common/DRAMPower/src -L../../common/DRAMPower/src
+  CXXFLAGS := -O3 -std=c++11 -g -w -Wall -I../common/DRAMPower/src -L../common/DRAMPower/src
   LDFLAGS := -lboost_program_options -ldrampowerxml -ldrampower -lxerces-c
 endif
 ifeq ($(UNAME_S), Darwin)

--- a/zsim-ramulator/setup.sh
+++ b/zsim-ramulator/setup.sh
@@ -12,5 +12,6 @@ apt-get -y install byacc
 #apt-get -y install libconfig++-dev
 apt-get -y install libhdf5-dev
 apt-get -y install libelf-dev
+apt-get -y install libxerces-c-dev
 
 ln -s /usr/include/asm-generic /usr/include/asm


### PR DESCRIPTION
Changelog: removed -Werror compilation flag, forced the use of g++-6 for compilation, top-level script to compile ramulator code, removed traces from the target list since it was dangling, changed the README, changed the relative path for include/libs on the Makefiles.